### PR TITLE
send completion block when there are no child nodes in tree

### DIFF
--- a/DRBOperationTree/DRBOperationTree.m
+++ b/DRBOperationTree/DRBOperationTree.m
@@ -67,6 +67,11 @@ static const NSUInteger kARSyncNodeMaxRetries = 3;
 
 - (void)sendObject:(id)object completion:(void(^)())completion
 {
+    if(_children.count == 0 && completion){
+        dispatch_sync(dispatch_get_main_queue(), completion);
+        return;
+    }
+
     dispatch_group_t group = dispatch_group_create();
     for (DRBOperationTree *child in _children) {
         dispatch_group_enter(group);


### PR DESCRIPTION
When testing a large operation tree, sometimes you want to just be sure that completion blocks are called without needing the full tree being set up. 

I could have set up a small tree for this, but it felt like this was really what matched my mental model of how it would work with no children. Presumably because there's no child operations that are ran in dispatch group then it won't run the completion block. Now completion blocks are always ran.
